### PR TITLE
Update styles.css

### DIFF
--- a/includes/styles.css
+++ b/includes/styles.css
@@ -4,6 +4,7 @@
 #AEA3B0 Heliotrope Gray
 #827081 Old Lavender
 #C6D2ED Periwinkle Crayola
+#514753 Crisp Serge
 
 */
 
@@ -194,7 +195,7 @@ label {
   margin-left: auto;
   margin-right: auto;
   border-left: 3px solid #514753;  /* Crisp Serge  */
-  border-bottom: 3px solid #514753;  /* Crisp Serge  */
+  
 }
 
 .book_results_container img {
@@ -219,6 +220,7 @@ label {
   padding: 5px;
   background: #C6D2ED; /* Periwinkle Crayola */
   color:#514753;  /* Crisp Serge  */
+  border-bottom: 3px solid #514753; /* Crisp Serge  */
 }
 
 .book_results_container img {


### PR DESCRIPTION
Issue:  On tables that contain multiple book entries, the bottom border was missing.
Resolution: Added a bottom-border attribute for the .book_results-cell class and removed the bottom-border attribute from 
the .book_results_container class to prevent double-bordering. 